### PR TITLE
Add GitHub organization profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,24 @@
+# 👋 Welcome to LINC BRAIN!
+
+The center for [Large-scale Imaging of Neural Circuits (LINC)](https://connects.mgh.harvard.edu/)
+ (PIs: Haber, Hillman, Yendiki) is funded by the
+ [NIH BRAIN Initiative CONNECTS program](https://www.ninds.nih.gov/news-events/highlights-announcements/nih-brain-initiative-launches-projects-develop-innovative-technologies-map-brain-incredible-detail).
+Its goal is to develop novel technologies for imaging brain connections down to 
+the microscopic scale, and deploy these technologies to image 
+cortico-subcortical projections that are relevant to deep brain stimulation for 
+motor and psychiatric disorders.  The LINC project is a collaboration between 8 
+institutions: Brigham and Women’s Hospital (PI: Fox), Columbia University (PI: 
+Hillman), Harvard University (PI: Lichtman), Massachusetts General Hospital (PI:
+ Yendiki), Massachusetts Institute of Technology (PI: Ghosh), University College
+ London (PI: Walsh, co-PI: Lee), University of Rochester (PI: Haber), and Weill 
+ Cornell Medicine (PI: Wu).
+
+In this GitHub organization are the source code, configuration, and 
+ documentation for the [LINC Cloud Platform](https://lincbrain.org/), which is 
+ used by the LINC team to share data and perform analysis.  As 
+ analysis methods become available they will be published here.
+
+## Quick Links
+
+- :computer: [LINC Homepage](https://connects.mgh.harvard.edu/)
+- :cloud: [LINC Cloud Platform](https://lincbrain.org/)

--- a/profile/README.md
+++ b/profile/README.md
@@ -16,7 +16,7 @@ Lichtman), Massachusetts General Hospital (PI: Yendiki), Massachusetts Institute
 
 In this GitHub organization are the source code, configuration, and 
  documentation for the [LINC Cloud Platform](https://lincbrain.org/), which is 
- used by the LINC team to share data and perform analysis.  As 
+ used by the LINC team to share data and run analysis.  As 
  analysis methods become available they will be published here.
 
 ## Quick Links

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,12 +6,13 @@ The center for [Large-scale Imaging of Neural Circuits (LINC)](https://connects.
 Its goal is to develop novel technologies for imaging brain connections down to 
 the microscopic scale, and deploy these technologies to image 
 cortico-subcortical projections that are relevant to deep brain stimulation for 
-motor and psychiatric disorders.  The LINC project is a collaboration between 8 
-institutions: Brigham and Women’s Hospital (PI: Fox), Columbia University (PI: 
-Hillman), Harvard University (PI: Lichtman), Massachusetts General Hospital (PI:
- Yendiki), Massachusetts Institute of Technology (PI: Ghosh), University College
- London (PI: Walsh, co-PI: Lee), University of Rochester (PI: Haber), and Weill 
- Cornell Medicine (PI: Wu).
+motor and psychiatric disorders.
+
+The LINC project is a collaboration between 8 institutions: Brigham and Women’s 
+Hospital (PI: Fox), Columbia University (PI: Hillman), Harvard University (PI: 
+Lichtman), Massachusetts General Hospital (PI: Yendiki), Massachusetts Institute
+ of Technology (PI: Ghosh), University College London (PI: Walsh, co-PI: Lee), 
+ University of Rochester (PI: Haber), and Weill Cornell Medicine (PI: Wu).
 
 In this GitHub organization are the source code, configuration, and 
  documentation for the [LINC Cloud Platform](https://lincbrain.org/), which is 


### PR DESCRIPTION
## Changes
- [x] Add the `profile/README.md` file which will show up as the [LINC BRAIN GitHub organization profile](https://github.com/lincbrain).  (I hope it is okay that I used the text directly from our main site: https://connects.mgh.harvard.edu/.)
- [x] Add gitignore